### PR TITLE
remove pods, add version

### DIFF
--- a/templates/aks-cluster/deploy.json
+++ b/templates/aks-cluster/deploy.json
@@ -52,10 +52,6 @@
             "type": "string",
             "minLength": 1
         },
-        "podCidr": {
-            "type": "string",
-            "minLength": 1
-        },
         "dockerBridgeCidr": {
             "type": "string",
             "minLength": 1
@@ -63,6 +59,10 @@
         "dnsServiceIP": {
             "type": "string",
             "minLength": 1
+        },
+        "kubernetesVersion":{
+            "type" : "string",
+            "defaultValue" : "1.15.11"
         }
     },
     "variables": {
@@ -76,6 +76,7 @@
             "location": "[parameters('location')]",
             "name": "[parameters('clusterName')]",
             "properties": {
+                "kubernetesVersion": "[parameters('kubernetesVersion')]",
                 "nodeResourceGroup": "[parameters('nodeResourceGroup')]",
                 "dnsPrefix": "[parameters('dnsPrefix')]",
                 "agentPoolProfiles": [
@@ -95,7 +96,6 @@
                 },
                 "networkProfile": {
                     "serviceCidr": "[parameters('serviceCidr')]",
-                    "podCidr":"[parameters('podCidr')]",
                     "dockerBridgeCidr": "[parameters('dockerBridgeCidr')]",
                     "dnsServiceIP": "[parameters('dnsServiceIP')]",
                     "networkPlugin": "azure"


### PR DESCRIPTION
pods are unnecessary for CNI networking and we need to set the version of kubernetes we are deploying.